### PR TITLE
Fix typings for React.FC

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.activeBackground": "#c749cd",
+    "activityBar.activeBorder": "#c8c137",
+    "activityBar.background": "#c749cd",
+    "activityBar.foreground": "#e7e7e7",
+    "activityBar.inactiveForeground": "#e7e7e799",
+    "activityBarBadge.background": "#c8c137",
+    "activityBarBadge.foreground": "#15202b",
+    "statusBar.background": "#ac31b2",
+    "statusBar.foreground": "#e7e7e7",
+    "statusBarItem.hoverBackground": "#c749cd",
+    "titleBar.activeBackground": "#ac31b2",
+    "titleBar.activeForeground": "#e7e7e7",
+    "titleBar.inactiveBackground": "#ac31b299",
+    "titleBar.inactiveForeground": "#e7e7e799"
+  },
+  "peacock.remoteColor": "#ac31b2"
+}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -6,7 +6,7 @@ import { jsx, Flex, Box, Heading, Image, Text } from "theme-ui";
 const DatahubLogo = "/images/datahub-logo.svg";
 const TSBLogo = "/images/tsb-logo.svg";
 
-export const Header: React.FC<any> = () => {
+export const Header: React.FC = () => {
   return (
     <Flex
       p={4}

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -67,6 +67,7 @@ export const Overview: React.FC = () => {
           {mockData.map((item) => {
             return (
               <ProjectPreview
+                key={item.id}
                 id={item.id}
                 title={item.title}
                 location={item.location}

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -36,7 +36,7 @@ const mockData = [
   },
 ];
 
-export const Overview: React.FC<any> = () => {
+export const Overview: React.FC = () => {
   return (
     <Container mt={5} p={4}>
       <Grid gap={4} columns={[3, "1fr 2fr"]}>

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import { useParams } from "react-router-dom";
 import { jsx } from "theme-ui";
 
-export const Project: React.FC<any> = () => {
-  let { id } = useParams();
+export const Project: React.FC = () => {
+  let { id } = useParams<{id: string}>();
   return <h1>Ein Projekt mit der ID: {id}</h1>;
 };

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -2,8 +2,10 @@
 import React from "react";
 import { useParams } from "react-router-dom";
 import { jsx } from "theme-ui";
-
+interface RouteParams {
+  id: string;
+}
 export const Project: React.FC = () => {
-  let { id } = useParams<{id: string}>();
+  let { id } = useParams<RouteParams>();
   return <h1>Ein Projekt mit der ID: {id}</h1>;
 };

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { jsx, Box, Card, Heading, Text, Grid } from "theme-ui";
+import { Box, Card, Heading, Text, Grid } from "theme-ui";
 
 export const ProjectPreview: React.FC<{
   id: string;

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -1,4 +1,3 @@
-/** @jsx jsx */
 import React from "react";
 import { Link } from "react-router-dom";
 import { jsx, Box, Card, Heading, Text, Grid } from "theme-ui";


### PR DESCRIPTION
- If you don't have any props you dont need to provide the `<any>`.
- Also adds interface to router `useParams()`
- Fixes things in a loop need a key warning. Which is pretty important for React as I learned recently. Also it never should be the `[].map(elem, i) => ` iterator