### PR TITLE
feat(DATAHUB-49): flexible line graph

### DIFF
--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,8 +1,8 @@
 /** @jsx jsx */
 import React from "react";
 import { jsx, Grid, Card, Box } from "theme-ui";
-import { IconButton } from "../IconButton";
-import { RecordType, DataTableType } from "../../common/interfaces";
+import { IconButton } from "./IconButton";
+import { RecordType, DataTableType } from "../common/interfaces";
 
 const downloadIcon = "./images/download.svg";
 

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -35,7 +35,7 @@ export const Overview: React.FC = () => {
             Offene Datenplattform für IoT-Projekte
           </Heading>
         </Box>
-        <Box>
+        <Box sx={{ maxWidth: "60ch" }}>
           <Text>
             Das Berlin Data Hub ist eine prototypische Offene Datenplattform,
             die Sensordaten aus Forschungsprojekten der Technologiestiftung

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -5,12 +5,13 @@ import { getRecords } from "../lib/requests";
 import { Link, useParams } from "react-router-dom";
 import { jsx, Grid, Container, Box, Card, IconButton, Text } from "theme-ui";
 import ArrowBackIcon from "@material-ui/icons/ArrowBack";
-import { ProjectSummary } from "./project/ProjectSummary";
-import { DataTable } from "./project/DataTable";
+import { ProjectSummary } from "./ProjectSummary";
+import { DataTable } from "./DataTable";
 import { IconButton as DownloadButton } from "./IconButton";
-import { ProjectType, DeviceType, RecordType } from "../common/interfaces";
+import { ProjectType, DeviceType } from "../common/interfaces";
 import { RadioTabs } from "./RadioTabs";
-import { LineGraph } from "./LineGraph";
+import { LineChart } from "./visualization/LineChart";
+import { createDateValueArray } from "../lib/utils";
 
 const downloadIcon = "./images/download.svg";
 
@@ -174,15 +175,10 @@ export const Project: React.FC = () => {
               )}
             <Box ref={parentRef} mt={4}>
               {selectedDevice && selectedDevice.records && (
-                <LineGraph
+                <LineChart
                   width={svgWrapperWidth}
                   height={svgWrapperHeight}
-                  data={selectedDevice.records.map((record: RecordType) => {
-                    return {
-                      date: new Date(record.recordedAt),
-                      value: record.value,
-                    };
-                  })}
+                  data={createDateValueArray(selectedDevice.records)}
                 />
               )}
             </Box>

--- a/src/components/ProjectSummary.tsx
+++ b/src/components/ProjectSummary.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import React from "react";
 import { jsx, Heading, Text, Box } from "theme-ui";
-import { SummaryType } from "../../common/interfaces";
+import { SummaryType } from "../common/interfaces";
 
 export const ProjectSummary: React.FC<SummaryType> = ({
   title,

--- a/src/components/visualization/LineChart.tsx
+++ b/src/components/visualization/LineChart.tsx
@@ -1,25 +1,17 @@
 /** @jsx jsx */
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import React from "react";
 import { jsx, useThemeUI } from "theme-ui";
 import { extent, max } from "d3-array";
-import { curveLinear } from "@visx/curve";
 import { Group } from "@visx/group";
-import { LinePath } from "@visx/shape";
-import { scaleTime, scaleLinear, scaleUtc, coerceNumber } from "@visx/scale";
+import { scaleLinear, scaleUtc } from "@visx/scale";
 import { AxisBottom, AxisLeft } from "@visx/axis";
 import { timeFormat } from "d3-time-format";
-import { DateValueType, LineGraphType } from "../common/interfaces";
+import { DateValueType, LineGraphType } from "../../common/interfaces";
+import { LinePath } from "./LinePath";
 
 const getX = (d: DateValueType) => d.date;
 const getY = (d: DateValueType) => d.value;
 
-const getMinMax = (vals: (number | { valueOf(): number })[]) => {
-  const numericVals = vals.map(coerceNumber);
-  return [Math.min(...numericVals), Math.max(...numericVals)];
-};
-
-export const LineGraph = ({ width, height, data }: LineGraphType) => {
+export const LineChart = ({ width, height, data }: LineGraphType) => {
   const context = useThemeUI();
   const { theme } = context;
 
@@ -29,31 +21,24 @@ export const LineGraph = ({ width, height, data }: LineGraphType) => {
   const graphWidth: number = width - paddingLeft - padding;
   const graphHeight: number = height - padding;
 
-  const xScale = scaleTime<number>({
+  const xScale = scaleUtc<number>({
     domain: extent(data, getX) as [Date, Date],
+    range: [0, graphWidth],
   });
 
   const yScale = scaleLinear<number>({
     domain: [0, max(data, getY) as number],
+    range: [graphHeight, 0],
   });
 
-  xScale.range([0, graphWidth]);
-  yScale.range([graphHeight, 0]);
-
   const xAxis = {
-    scale: scaleUtc({
-      domain: getMinMax(data.map((el) => el.date)),
-      range: [0, graphWidth],
-    }),
+    scale: xScale,
     values: data.map((el) => el.date),
     tickFormat: (v: Date) => timeFormat("%H:%M:%S"),
   };
 
   const yAxis = {
-    scale: scaleLinear({
-      domain: getMinMax(data.map((el) => el.value)),
-      range: [graphHeight, 0],
-    }),
+    scale: yScale,
     values: data.map((el) => el.value),
   };
 
@@ -88,21 +73,7 @@ export const LineGraph = ({ width, height, data }: LineGraphType) => {
         }
       />
       <Group left={paddingLeft}>
-        <LinePath<DateValueType>
-          curve={curveLinear}
-          data={data}
-          // TODO: [DATAHUB-36] Type this function
-          // @ts-ignore
-          x={(d) => xScale(getX(d))}
-          // @ts-ignore
-          y={(d) => yScale(getY(d))}
-          sx={{
-            stroke: "primary",
-            strokeWidth: 2,
-            strokeOpacity: 1,
-            shapeRendering: "geometricPrecision",
-          }}
-        />
+        <LinePath width={graphWidth} height={graphHeight} data={data} />
       </Group>
     </svg>
   );

--- a/src/components/visualization/LinePath.tsx
+++ b/src/components/visualization/LinePath.tsx
@@ -1,0 +1,40 @@
+/** @jsx jsx */
+import { jsx } from "theme-ui";
+import { extent, max } from "d3-array";
+import { curveLinear } from "@visx/curve";
+import { LinePath as Path } from "@visx/shape";
+import { scaleLinear, scaleUtc } from "@visx/scale";
+import { DateValueType, LineGraphType } from "../../common/interfaces";
+
+const getX = (d: DateValueType) => d.date;
+const getY = (d: DateValueType) => d.value;
+
+export const LinePath = ({ width, height, data }: LineGraphType) => {
+  const xScale = scaleUtc<number>({
+    domain: extent(data, getX) as [Date, Date],
+    range: [0, width],
+  });
+
+  const yScale = scaleLinear<number>({
+    domain: [0, max(data, getY) as number],
+    range: [height, 0],
+  });
+
+  return (
+    <Path<DateValueType>
+      curve={curveLinear}
+      data={data}
+      // TODO: [DATAHUB-36] Type this function
+      // @ts-ignore
+      x={(d) => xScale(getX(d))}
+      // @ts-ignore
+      y={(d) => yScale(getY(d))}
+      sx={{
+        stroke: "primary",
+        strokeWidth: 2,
+        strokeOpacity: 1,
+        shapeRendering: "geometricPrecision",
+      }}
+    />
+  );
+};

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,11 @@
+import { RecordType, DateValueType } from "../common/interfaces";
+
+export const createDateValueArray = (input: RecordType[]) => {
+  const dateValueArray = input.map((record: RecordType) => {
+    return {
+      value: record.value,
+      date: new Date(record.recordedAt),
+    };
+  });
+  return dateValueArray as DateValueType[];
+};


### PR DESCRIPTION
This PR restructures the line path/chart elements, so that the line path can be used without the axes etc. This is necessary because in the project preview cards, we display a line path this way.

The line paths/charts are now added in their respective places.

This PR also does some restructuring to find components more intuitively, and minor styling stuff.