### PR TITLE
refactor(DATAHUB-72): use device id

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -188,10 +188,16 @@ export interface LineGraphType {
   data: Array<DateValueType>;
 }
 
+export interface RadioTabOptionType {
+  title: string;
+  id: number;
+  isActive: boolean;
+}
+
 export interface RadioTabsType {
   name: string;
-  options: Array<string>;
-  changeHandler: (selected: string) => void;
+  options: RadioTabOptionType[];
+  changeHandler: (selected: number) => void;
 }
 
 export interface IconButtonType {
@@ -211,5 +217,5 @@ export interface MarkerType {
   latitude: number;
   longitude: number;
   id: number;
-  active?: boolean;
+  isActive: boolean;
 }

--- a/src/components/MarkerMap.tsx
+++ b/src/components/MarkerMap.tsx
@@ -98,7 +98,7 @@ export const MarkerMap: React.FC<{
                 width: "24px",
                 height: "24px",
                 borderRadius: "50%",
-                bg: marker.active ? "primary" : "mediumgrey",
+                bg: marker.isActive ? "primary" : "mediumgrey",
                 cursor: "pointer",
                 transform: "translate(-12px, -12px)",
               }}

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -31,7 +31,7 @@ export const Project: React.FC = () => {
     projectWithoutRecords
   );
 
-  const [selectedDeviceId, setSelectedDeviceId] = useState<string | undefined>(
+  const [selectedDeviceId, setSelectedDeviceId] = useState<number | undefined>(
     undefined
   );
 
@@ -70,7 +70,7 @@ export const Project: React.FC = () => {
           ...projectWithoutRecords,
           devices: devicesWithRecords,
         });
-        setSelectedDeviceId(devicesWithRecords[0].ttnDeviceId);
+        setSelectedDeviceId(devicesWithRecords[0].id);
         setSelectedDevice(devicesWithRecords[0]);
         setMarkerData(
           devicesWithRecords
@@ -82,7 +82,7 @@ export const Project: React.FC = () => {
                 latitude: device.latitude,
                 longitude: device.longitude,
                 id: device.id,
-                active: i === 0,
+                isActive: device.id === devicesWithRecords[0].id,
               };
             })
         );
@@ -95,7 +95,7 @@ export const Project: React.FC = () => {
     if (!completeProjectData) return;
     setSelectedDevice(
       completeProjectData.devices.find(
-        (device) => device.ttnDeviceId === selectedDeviceId
+        (device) => device.id === selectedDeviceId
       )
     );
   }, [selectedDeviceId, completeProjectData]);
@@ -113,7 +113,7 @@ export const Project: React.FC = () => {
             latitude: device.latitude,
             longitude: device.longitude,
             id: device.id,
-            active: device.ttnDeviceId === selectedDeviceId,
+            isActive: device.id === selectedDeviceId,
           };
         })
     );
@@ -172,11 +172,7 @@ export const Project: React.FC = () => {
   };
 
   const handleMarkerSelect = (deviceId: number) => {
-    setSelectedDeviceId(
-      completeProjectData.devices.find((device: DeviceType) => {
-        return device.id === deviceId;
-      })?.ttnDeviceId
-    );
+    setSelectedDeviceId(deviceId);
   };
 
   return (
@@ -268,17 +264,15 @@ export const Project: React.FC = () => {
                   <RadioTabs
                     name={"devices"}
                     options={completeProjectData.devices.map(
-                      (device: DeviceType) => device.description
+                      (device: DeviceType) => {
+                        return {
+                          title: device.description,
+                          id: device.id,
+                          isActive: device.id === selectedDeviceId,
+                        };
+                      }
                     )}
-                    changeHandler={(selected) =>
-                      setSelectedDeviceId(
-                        completeProjectData.devices.find(
-                          (device: DeviceType) => {
-                            return device.description === selected;
-                          }
-                        )?.ttnDeviceId
-                      )
-                    }
+                    changeHandler={(selected) => setSelectedDeviceId(selected)}
                   />
                   <Text>
                     {selectedDevice.records.length &&

--- a/src/components/RadioTabs.tsx
+++ b/src/components/RadioTabs.tsx
@@ -1,26 +1,23 @@
 /** @jsx jsx */
-import React, { useState } from "react";
+import React from "react";
 import { jsx, Box } from "theme-ui";
-import { RadioTabsType } from "../common/interfaces";
+import { RadioTabsType, RadioTabOptionType } from "../common/interfaces";
 
 export const RadioTabs: React.FC<RadioTabsType> = ({
   name,
   options,
   changeHandler,
 }) => {
-  const [checked, setChecked] = useState(0);
-
   const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setChecked(options.indexOf(event.target.value));
-    changeHandler(event.target.value);
+    changeHandler(Number(event.target.value));
   };
 
   return (
     <Box>
-      {options.map((option: string, i: number) => {
+      {options.map((option: RadioTabOptionType) => {
         return (
           <div
-            key={i}
+            key={`device-${option.id}-tab`}
             sx={{
               display: "inline-block",
               marginRight: (theme) => `${theme.space[3]}px`,
@@ -28,10 +25,10 @@ export const RadioTabs: React.FC<RadioTabsType> = ({
           >
             <input
               type="radio"
-              id={`${i}`}
+              id={`device-${option.id}`}
               name={name}
-              value={option}
-              checked={checked === i}
+              value={option.id}
+              checked={option.isActive}
               onChange={handleChange}
               sx={{
                 opacity: 0,
@@ -39,9 +36,9 @@ export const RadioTabs: React.FC<RadioTabsType> = ({
               }}
             />
             <label
-              htmlFor={`${i}`}
+              htmlFor={`device-${option.id}`}
               sx={{
-                color: checked === i ? "primary" : "lightgrey",
+                color: option.isActive ? "primary" : "lightgrey",
                 cursor: "pointer",
                 transition: "all .1s ease-out",
                 "&:hover": {
@@ -49,7 +46,7 @@ export const RadioTabs: React.FC<RadioTabsType> = ({
                 },
               }}
             >
-              {option}
+              {option.title}
             </label>
           </div>
         );


### PR DESCRIPTION
This PR makes the device field `id` the primary key for handling selection of devices (previously `ttnDeviceId` was in use).

Additionally, this fixes the tabs on the project page that were out of sync with the selected device when changed via the map markers.