### PR TITLE
refactor(DATAHUB-76): update API calls

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=""

--- a/README.md
+++ b/README.md
@@ -16,15 +16,27 @@ The folder structure follows CRA's recommendations.
 
 ### Views and components
 
-`App.tsx` contains the routes/views that are currently available. The views themselves are simply React components that can be found in `src/components`. All other components can be found there as well.
+`src/App.tsx` contains the routes/views that are currently available. The views themselves are simply React components that can be found in `src/components`. All other components can be found there as well.
 
 ### Requests
 
-Requests to the API are defined in `lib/requests.ts`. The returned projects are stored in `state/store.ts`. The `Project.tsx` view currently does not communicate with the store, as the records data for each device is not needed anywhere else. Records data is requested from the API right in this file and forwarded to the relevant components.
+Requests to the API are defined in `src/lib/requests.ts` and called in currently three places:
+
+- `src/state/store.ts` (for fetching all projects to be displayed on the homepage)
+- `src/components/Project.tsx` (for fetching records of all devices associated with the project)
+- `src/components/ProjectPreview.tsx` (for fetching the records of one project device, to be displayed in the project preview)
+
+The requests are constructed following this pattern:
+
+```
+{API_URL}/api/{API_VERSION}/route/to/endpoint
+```
+
+The API version can be defined in `src/lib/requests.ts`.
 
 ### Styling
 
-This project uses [Theme UI](https://theme-ui.com/home) for styling. Main style definitions can be found in `style/theme.ts`. The theme can be referenced in every component. For visual consistency, definitions from the theme should be used whenever possible. Information about using the theme can be found in Theme UI's docs.
+This project uses [Theme UI](https://theme-ui.com/home) for styling. Main style definitions can be found in `src/style/theme.ts`. The theme can be referenced in every component. For visual consistency, definitions from the theme should be used whenever possible. Information about using the theme can be found in Theme UI's docs.
 
 ## Workflow
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The API for retrieving data can found in a [different repository](https://github
 
 Clone this repository, then on the root level create a file named `.env` and fill in the required values (see `.env.example` for a reference).
 
+Currently we are not calling the actual API in dev mode, so the `.env.development` file (that comes with the repository) redirects API calls to our mock service worker.
+
 Run `npm install` to install all required dependencies and then `npm start` to start developing locally. All available script can be found further down.
 
 ## Structure

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -1,7 +1,7 @@
 /** @jsx jsx */
 import React, { useEffect, useRef, useState } from "react";
 import { useStoreState } from "../state/hooks";
-import { getRecords } from "../lib/requests";
+import { getRecords, API_VERSION } from "../lib/requests";
 import { Link, useParams } from "react-router-dom";
 import { jsx, Grid, Container, Box, Card, IconButton, Text } from "theme-ui";
 import { downloadMultiple } from "../lib/download-handlers";
@@ -51,7 +51,7 @@ export const Project: React.FC = () => {
         const {
           data: { records },
         } = await getRecords(
-          `${process.env.REACT_APP_API_URL}/api/devices/${device.id}/records`
+          `${process.env.REACT_APP_API_URL}/api/${API_VERSION}/devices/${device.id}/records`
         );
         return records;
       })

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -4,7 +4,7 @@ import { Link } from "react-router-dom";
 import { jsx, Box, Card, Heading, Text, Grid, Flex } from "theme-ui";
 import { ProjectType, DateValueType } from "../common/interfaces";
 import { LinePath } from "./visualization/LinePath";
-import { getRecords } from "../lib/requests";
+import { getRecords, API_VERSION } from "../lib/requests";
 import { createDateValueArray } from "../lib/utils";
 
 export const ProjectPreview: React.FC<ProjectType> = ({
@@ -22,7 +22,7 @@ export const ProjectPreview: React.FC<ProjectType> = ({
       const {
         data: { records },
       } = await getRecords(
-        `${process.env.REACT_APP_API_URL}/api/devices/${devices[0].id}/records`
+        `${process.env.REACT_APP_API_URL}/api/${API_VERSION}/devices/${devices[0].id}/records`
       );
       return records;
     };

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -21,7 +21,7 @@ export const ProjectPreview: React.FC<ProjectType> = ({
       const {
         data: { devices },
       } = await getDevices(
-        `${process.env.REACT_APP_API_URL}/api/projects/${id}/devices`
+        `${process.env.REACT_APP_API_URL}/api/${API_VERSION}/projects/${id}/devices`
       );
 
       if (devices.length < 1) return;

--- a/src/lib/requests.ts
+++ b/src/lib/requests.ts
@@ -1,5 +1,7 @@
 import { DeviceType, RecordType, ProjectType } from "../common/interfaces";
 
+export const API_VERSION: string = "v1";
+
 interface ProjectResponse {
   data: {
     projects: ProjectType[];

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -8,6 +8,7 @@ import {
   device3Records,
   device4Records,
 } from "./data";
+import { API_VERSION } from "../lib/requests";
 
 const { data: projectsData } = projectsResponse;
 const { data: project1DevicesData } = project1Devices;
@@ -18,43 +19,43 @@ const { data: device3RecordsData } = device3Records;
 const { data: device4RecordsData } = device4Records;
 
 export const handlers = [
-  rest.get(`/api/projects`, (_req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/projects`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: projectsData, meta: "mocked" })
     );
   }),
-  rest.get(`/api/projects/1/devices`, (req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/projects/1/devices`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: project1DevicesData, meta: "mocked" })
     );
   }),
-  rest.get(`/api/projects/2/devices`, (req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/projects/2/devices`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: project2DevicesData, meta: "mocked" })
     );
   }),
-  rest.get(`/api/devices/1/records`, (req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/devices/1/records`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: device1RecordsData, meta: "mocked" })
     );
   }),
-  rest.get(`/api/devices/2/records`, (req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/devices/2/records`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: device2RecordsData, meta: "mocked" })
     );
   }),
-  rest.get(`/api/devices/3/records`, (req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/devices/3/records`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: device3RecordsData, meta: "mocked" })
     );
   }),
-  rest.get(`/api/devices/4/records`, (req, res, ctx) => {
+  rest.get(`/api/${API_VERSION}/devices/4/records`, (_req, res, ctx) => {
     return res(
       ctx.status(201, "Mocked status"),
       ctx.json({ data: device4RecordsData, meta: "mocked" })

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -1,6 +1,6 @@
 import { createStore, thunk, action, computed } from "easy-peasy";
 import { StoreModel } from "./model";
-import { getDevices, getProjects } from "../lib/requests";
+import { getDevices, getProjects, API_VERSION } from "../lib/requests";
 import { ProjectType } from "../common/interfaces";
 
 const store = createStore<StoreModel>({
@@ -16,14 +16,16 @@ const store = createStore<StoreModel>({
     load: thunk(async (actions) => {
       const {
         data: { projects },
-      } = await getProjects(`${process.env.REACT_APP_API_URL}/api/projects`);
+      } = await getProjects(
+        `${process.env.REACT_APP_API_URL}/api/${API_VERSION}/projects`
+      );
 
       Promise.all(
         projects.map(async (project: ProjectType) => {
           const {
             data: { devices },
           } = await getDevices(
-            `${process.env.REACT_APP_API_URL}/api/projects/${project.id}/devices`
+            `${process.env.REACT_APP_API_URL}/api/${API_VERSION}/projects/${project.id}/devices`
           );
           return {
             ...project,


### PR DESCRIPTION
This PR updates the API calls to use the new versioning schema of the API and documents the usage in the frontend.

From this PR on, we are using mock data for developing locally. This can be reverted whenever it should become necessary.