### PR TITLE
feat(DATAHUB-73): cookie banner

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -3,11 +3,15 @@ import { render } from "@testing-library/react";
 import App from "./App";
 import { StoreProvider } from "easy-peasy";
 import store from "./state/store";
+import { ThemeProvider } from "theme-ui";
+import theme from "./style/theme";
 
 test("renders claim element", () => {
   const { getByText } = render(
     <StoreProvider store={store}>
-      <App />
+      <ThemeProvider theme={theme}>
+        <App />
+      </ThemeProvider>
     </StoreProvider>
   );
   const claimElement = getByText(/Offene Datenplattform für IoT-Projekte/i);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { BrowserRouter as Router, useLocation } from "react-router-dom";
 import { Header } from "./components/Header";
 import { MainArea } from "./components/MainArea";
 import { Footer } from "./components/Footer";
+import { CookieBanner } from "./components/CookieBanner";
 
 const ScrollToTop: React.FC = () => {
   const { pathname } = useLocation();
@@ -28,6 +29,7 @@ const App: React.FC = () => {
       <Header />
       <MainArea />
       <Footer />
+      <CookieBanner />
     </Router>
   );
 };

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -1,0 +1,72 @@
+/** @jsx jsx */
+import React, { useState } from "react";
+import { jsx, Text, Link, Flex, Box } from "theme-ui";
+import CloseIcon from "@material-ui/icons/Close";
+
+export const CookieBanner: React.FC = () => {
+  const [cookieStatus, setCookieStatus] = useState<boolean>(
+    document.cookie
+      .split("; ")
+      .find((row) => row.startsWith("disclaimerAccepted")) !== undefined
+      ? true
+      : false
+  );
+
+  const acceptCookies: () => void = () => {
+    document.cookie = "disclaimerAccepted=true;path=/;max-age=31536000;";
+    setCookieStatus(true);
+  };
+
+  return (
+    <React.Fragment>
+      {cookieStatus === false && (
+        <Flex
+          color="text"
+          bg="background"
+          p={3}
+          sx={{
+            fontSize: 0,
+            width: [
+              (theme) => `calc(100% - ${theme.space[3]}px)`,
+              "80%",
+              "60%",
+            ],
+            border: (theme) => `2px solid ${theme.colors.primary}`,
+            position: "fixed",
+            bottom: [(theme) => `${theme.space[2]}px`, "40px", null],
+            left: [(theme) => `${theme.space[2]}px`, "10%", "20%"],
+            zIndex: 3,
+          }}
+        >
+          <Box
+            sx={{
+              "& > *": {
+                display: "inline",
+              },
+            }}
+          >
+            <Text>
+              Diese Webseite verwendet Cookies, um bestimmte Funktionen zu
+              ermöglichen und das Angebot zu verbessern. Indem Sie hier
+              fortfahrens stimmen Sie der Nutzung von Cookies zu.
+            </Text>
+            &nbsp;
+            <Link
+              href="https://www.technologiestiftung-berlin.de/de/datenschutz/"
+              target="_blank"
+              rel="noopener noreferrer"
+              sx={{ color: "primary" }}
+            >
+              Weitere Informationen
+            </Link>
+          </Box>
+          <CloseIcon
+            fontSize="large"
+            sx={{ color: "primary", cursor: "pointer" }}
+            onClick={acceptCookies}
+          />
+        </Flex>
+      )}
+    </React.Fragment>
+  );
+};

--- a/src/components/CookieBanner.tsx
+++ b/src/components/CookieBanner.tsx
@@ -48,7 +48,7 @@ export const CookieBanner: React.FC = () => {
             <Text>
               Diese Webseite verwendet Cookies, um bestimmte Funktionen zu
               ermöglichen und das Angebot zu verbessern. Indem Sie hier
-              fortfahrens stimmen Sie der Nutzung von Cookies zu.
+              fortfahren, stimmen Sie der Nutzung von Cookies zu.
             </Text>
             &nbsp;
             <Link

--- a/src/components/Overview.tsx
+++ b/src/components/Overview.tsx
@@ -21,20 +21,37 @@ export const Overview: React.FC = () => {
 
   return (
     <Container mt={[0, 5, 5]} p={4}>
-      <Grid gap={[4, 4, 6]} columns={[1, null, "1fr 2fr"]}>
-        <Box>
+      <Grid gap={[4, null, null]} columns={[1, null, "1fr 2fr"]}>
+        <Grid
+          gap={[0, 4, 0]}
+          columns={[1, "max-content auto", 1]}
+          sx={{
+            maxWidth: ["60ch", null, "none"],
+            gridTemplateRows: "max-content auto",
+          }}
+        >
           <Image
             src={DatahubLogo}
             alt={"Logo des Berlin IoT Hub"}
-            sx={{ minWidth: "240px" }}
+            sx={{
+              minWidth: "240px",
+              display: ["none", "block", null],
+            }}
           />
-          <Heading as="h1" variant="h1" mt={4} sx={{ color: "text" }}>
-            Berlin <span sx={{ fontWeight: "body" }}>IoT Hub</span>
-          </Heading>
-          <Heading as="h2" variant="h2" mt={2} sx={{ color: "primary" }}>
-            Offene Datenplattform für IoT-Projekte
-          </Heading>
-        </Box>
+          <Box>
+            <Heading
+              as="h1"
+              variant="h1"
+              mt={[0, null, 4]}
+              sx={{ color: "text" }}
+            >
+              Berlin <span sx={{ fontWeight: "body" }}>IoT Hub</span>
+            </Heading>
+            <Heading as="h2" variant="h2" mt={2} sx={{ color: "primary" }}>
+              Offene Datenplattform für IoT-Projekte
+            </Heading>
+          </Box>
+        </Grid>
         <Box sx={{ maxWidth: "60ch" }}>
           <Text>
             Das Berlin IoT Hub ist eine prototypische Offene Datenplattform, die


### PR DESCRIPTION
This PR adds a cookie banner for the Mapbox cookies.

Closing the banner accepts cookies for 1 year - banner won't show up in that time (unless user removes cookies).