### PR TITLE
fix(DATAHUB-103): map display

### DIFF
--- a/src/components/MarkerCircle.tsx
+++ b/src/components/MarkerCircle.tsx
@@ -1,0 +1,27 @@
+/** @jsx jsx */
+import React from "react";
+import { jsx } from "theme-ui";
+
+export const MarkerCircle: React.FC<{
+  isActive: boolean;
+  clickHandler?: () => void;
+  children?: React.ReactNode;
+}> = ({ isActive, clickHandler, children }) => {
+  return (
+    <div
+      sx={{
+        width: "24px",
+        height: "24px",
+        borderRadius: "50%",
+        bg: isActive ? "primary" : "mediumgrey",
+        color: "background",
+        textAlign: "center",
+        transform: "translate(-12px, -12px)",
+        cursor: clickHandler ? "pointer" : "default",
+      }}
+      onClick={() => (clickHandler ? clickHandler() : null)}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/MarkerMap.tsx
+++ b/src/components/MarkerMap.tsx
@@ -29,8 +29,8 @@ export const MarkerMap: React.FC<{
   mapHeight: number;
 }> = ({ markers, clickHandler, mapWidth, mapHeight }) => {
   const [viewport, setViewport] = useState<ViewportType>({
-    latitude: markers.length === 1 ? markers[0].latitude : 52.520952,
-    longitude: markers.length === 1 ? markers[0].longitude : 13.400033,
+    latitude: 52.520952,
+    longitude: 13.400033,
     zoom: 12,
     bearing: 0,
     pitch: 0,
@@ -40,7 +40,30 @@ export const MarkerMap: React.FC<{
   });
 
   useEffect(() => {
-    if (markers.length === 1) return;
+    const latLonItems: { latitude: number; longitude: number }[] = markers.map(
+      (marker: MarkerType) => {
+        return {
+          latitude: marker.latitude,
+          longitude: marker.longitude,
+        };
+      }
+    );
+
+    const allDevicesHaveSameLocation: boolean = latLonItems.every((item) => {
+      return (
+        item.latitude === latLonItems[0].latitude &&
+        item.longitude === latLonItems[0].longitude
+      );
+    });
+
+    if (markers.length === 1 || allDevicesHaveSameLocation) {
+      setViewport({
+        ...viewport,
+        latitude: markers[0].latitude,
+        longitude: markers[0].longitude,
+      });
+      return;
+    }
 
     const features = featureCollection(
       markers.map((marker: MarkerType) => {

--- a/src/components/MarkerMap.tsx
+++ b/src/components/MarkerMap.tsx
@@ -4,6 +4,7 @@ import ReactMapGL, { Marker, WebMercatorViewport } from "react-map-gl";
 import { bbox, featureCollection, point } from "@turf/turf";
 import { jsx } from "theme-ui";
 import { MarkerType } from "../common/interfaces";
+import { MarkerCircle } from "./MarkerCircle";
 
 import "mapbox-gl/dist/mapbox-gl.css";
 
@@ -39,23 +40,23 @@ export const MarkerMap: React.FC<{
     height: mapHeight,
   });
 
-  useEffect(() => {
-    const latLonItems: { latitude: number; longitude: number }[] = markers.map(
-      (marker: MarkerType) => {
-        return {
-          latitude: marker.latitude,
-          longitude: marker.longitude,
-        };
-      }
+  const latLonItems: { latitude: number; longitude: number }[] = markers.map(
+    (marker: MarkerType) => {
+      return {
+        latitude: marker.latitude,
+        longitude: marker.longitude,
+      };
+    }
+  );
+
+  const allDevicesHaveSameLocation: boolean = latLonItems.every((item) => {
+    return (
+      item.latitude === latLonItems[0].latitude &&
+      item.longitude === latLonItems[0].longitude
     );
+  });
 
-    const allDevicesHaveSameLocation: boolean = latLonItems.every((item) => {
-      return (
-        item.latitude === latLonItems[0].latitude &&
-        item.longitude === latLonItems[0].longitude
-      );
-    });
-
+  useEffect(() => {
     if (markers.length === 1 || allDevicesHaveSameLocation) {
       setViewport({
         ...viewport,
@@ -109,27 +110,28 @@ export const MarkerMap: React.FC<{
       onViewportChange={(nextViewport) => setViewport(nextViewport)}
       mapboxApiAccessToken={MAPBOX_TOKEN}
     >
-      {markers.map((marker: MarkerType) => {
-        return (
-          <Marker
-            key={marker.id}
-            latitude={marker.latitude}
-            longitude={marker.longitude}
-          >
-            <div
-              sx={{
-                width: "24px",
-                height: "24px",
-                borderRadius: "50%",
-                bg: marker.isActive ? "primary" : "mediumgrey",
-                cursor: "pointer",
-                transform: "translate(-12px, -12px)",
-              }}
-              onClick={() => handleClick(marker.id)}
-            ></div>
-          </Marker>
-        );
-      })}
+      {!allDevicesHaveSameLocation &&
+        markers.map((marker: MarkerType) => {
+          return (
+            <Marker
+              key={marker.id}
+              latitude={marker.latitude}
+              longitude={marker.longitude}
+            >
+              <MarkerCircle
+                isActive={marker.isActive}
+                clickHandler={() => handleClick(marker.id)}
+              ></MarkerCircle>
+            </Marker>
+          );
+        })}
+      {allDevicesHaveSameLocation && (
+        <Marker latitude={markers[0].latitude} longitude={markers[0].longitude}>
+          <MarkerCircle isActive>
+            {markers.length === 1 ? "" : markers.length}
+          </MarkerCircle>
+        </Marker>
+      )}
     </ReactMapGL>
   );
 };


### PR DESCRIPTION
This PR fixes the map: When all devices had the same location, the map would zoom in so much that the surroundings were not visible. This was because of the dynamic calculation of the map's bounding box.

This PR prevents that zooming. It also adds a label in the marker(s) when all devices have the same location, indicating the number of devices at that location. Click events are disabled in that case.