### PR TITLE
fix(DATAHUB-106): sort line graph data by time

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,10 @@ export const createDateValueArray = (input: RecordType[]) => {
       date: new Date(record.recordedAt),
     };
   });
-  return dateValueArray as DateValueType[];
+  const sortedDateValueArray = dateValueArray.sort((a, b) => {
+    return a.date.getTime() - b.date.getTime();
+  });
+  return sortedDateValueArray as DateValueType[];
 };
 
 export const createTimeOutput = (input: Date): string => {


### PR DESCRIPTION
When records were not sorted by time in the database, the line graph was getting messed up.

This PR introduces time sorting of the line graph data in the frontend.