### PR TITLE
feat(DATAHUB-105): limit displayed data

### DIFF
--- a/src/common/interfaces.ts
+++ b/src/common/interfaces.ts
@@ -131,10 +131,6 @@ export interface Theme {
       "&:hover": {
         cursor: string;
       };
-      "&:focus": {
-        bg: string;
-        outline: string;
-      };
     };
   };
   links: {
@@ -150,6 +146,14 @@ export interface Theme {
       "&:active": {
         bg: string;
       };
+    };
+  };
+  forms: {
+    input: {
+      border: string;
+      borderRadius: string;
+      padding: number;
+      bg: string;
     };
   };
 }

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -116,7 +116,7 @@ export const DataTable: React.FC<DataTableType> = ({ data, title }) => {
         </table>
         {data && data.length > numberOfRecordsToDisplay && (
           <Button variant="text" mt={3} onClick={handleLoadMore}>
-            Mehr laden
+            Mehr anzeigen
           </Button>
         )}
       </Box>

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -5,14 +5,13 @@ import { IconButton } from "./IconButton";
 import { RecordType, DataTableType } from "../common/interfaces";
 import { createTimeOutput } from "../lib/utils";
 import { createCSVStructure, downloadCSV } from "../lib/download-handlers";
-import { useStoreState } from "easy-peasy";
-import { StoreModel } from "../state/model";
+import { useStoreState } from "../state/hooks";
 
 const downloadIcon = "./images/download.svg";
 
 export const DataTable: React.FC<DataTableType> = ({ data, title }) => {
   const recordsSegmentSize = useStoreState(
-    (state: StoreModel) => state.records.segmentSize
+    (state) => state.records.segmentSize
   );
 
   const [displayedData, setDisplayedData] = useState<undefined | RecordType[]>(

--- a/src/components/DataTable.tsx
+++ b/src/components/DataTable.tsx
@@ -1,17 +1,45 @@
 /** @jsx jsx */
-import React from "react";
-import { jsx, Grid, Card, Box } from "theme-ui";
+import React, { useState, useEffect } from "react";
+import { jsx, Grid, Card, Box, Button } from "theme-ui";
 import { IconButton } from "./IconButton";
 import { RecordType, DataTableType } from "../common/interfaces";
 import { createTimeOutput } from "../lib/utils";
 import { createCSVStructure, downloadCSV } from "../lib/download-handlers";
+import { useStoreState } from "easy-peasy";
+import { StoreModel } from "../state/model";
 
 const downloadIcon = "./images/download.svg";
 
 export const DataTable: React.FC<DataTableType> = ({ data, title }) => {
+  const recordsSegmentSize = useStoreState(
+    (state: StoreModel) => state.records.segmentSize
+  );
+
+  const [displayedData, setDisplayedData] = useState<undefined | RecordType[]>(
+    undefined
+  );
+
+  const [numberOfRecordsToDisplay, setNumberOfRecordsToDisplay] = useState<
+    number
+  >(recordsSegmentSize);
+
+  useEffect(() => {
+    if (!data) return;
+
+    setDisplayedData(
+      data
+        .sort((a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt))
+        .filter((_record, i: number) => i < numberOfRecordsToDisplay)
+    );
+  }, [data, numberOfRecordsToDisplay]);
+
   const handleDownload = (): void => {
     const CSVData = createCSVStructure(data);
     downloadCSV(CSVData, title);
+  };
+
+  const handleLoadMore = (): void => {
+    setNumberOfRecordsToDisplay(numberOfRecordsToDisplay + recordsSegmentSize);
   };
 
   return (
@@ -35,7 +63,10 @@ export const DataTable: React.FC<DataTableType> = ({ data, title }) => {
           />
         </Box>
       </Grid>
-      <Box p={3}>
+      <Box
+        p={3}
+        sx={{ display: "flex", flexWrap: "wrap", justifyContent: "center" }}
+      >
         <table
           sx={{
             width: "100%",
@@ -62,32 +93,33 @@ export const DataTable: React.FC<DataTableType> = ({ data, title }) => {
             </tr>
           </thead>
           <tbody>
-            {data &&
-              data
-                .sort(
-                  (a, b) => Date.parse(b.recordedAt) - Date.parse(a.recordedAt)
-                )
-                .map((el: RecordType, i: number) => {
-                  return (
-                    <tr
-                      key={i}
-                      sx={{
-                        backgroundColor: () =>
-                          `${i % 2 === 0 ? "muted" : "background"}`,
-                        "& > td": {
-                          p: 2,
-                          border: "none",
-                        },
-                      }}
-                    >
-                      <td>{new Date(el.recordedAt).toLocaleDateString()}</td>
-                      <td>{createTimeOutput(new Date(el.recordedAt))}</td>
-                      <td sx={{ textAlign: "right" }}>{el.value}</td>
-                    </tr>
-                  );
-                })}
+            {displayedData &&
+              displayedData.map((record: RecordType, i: number) => {
+                return (
+                  <tr
+                    key={record.id}
+                    sx={{
+                      backgroundColor: () =>
+                        `${i % 2 === 0 ? "muted" : "background"}`,
+                      "& > td": {
+                        p: 2,
+                        border: "none",
+                      },
+                    }}
+                  >
+                    <td>{new Date(record.recordedAt).toLocaleDateString()}</td>
+                    <td>{createTimeOutput(new Date(record.recordedAt))}</td>
+                    <td sx={{ textAlign: "right" }}>{record.value}</td>
+                  </tr>
+                );
+              })}
           </tbody>
         </table>
+        {data && data.length > numberOfRecordsToDisplay && (
+          <Button variant="text" mt={3} onClick={handleLoadMore}>
+            Mehr laden
+          </Button>
+        )}
       </Box>
     </Card>
   );

--- a/src/components/ProjectPreview.tsx
+++ b/src/components/ProjectPreview.tsx
@@ -62,7 +62,7 @@ export const ProjectPreview: React.FC<ProjectType> = ({
     return () => {
       isMounted = false;
     };
-  }, [id]);
+  }, [id, numberOfRecordsToDisplay]);
 
   const parentRef = useRef<HTMLDivElement>(null);
   const [svgWrapperWidth, setSvgWrapperWidth] = useState(0);

--- a/src/components/RadioTabs.tsx
+++ b/src/components/RadioTabs.tsx
@@ -17,7 +17,7 @@ export const RadioTabs: React.FC<RadioTabsType> = ({
       {options.map((option: RadioTabOptionType) => {
         return (
           <div
-            key={`device-${option.id}-tab`}
+            key={`${name}-${option.id}-tab`}
             sx={{
               display: "inline-block",
               marginRight: (theme) => `${theme.space[3]}px`,
@@ -25,7 +25,7 @@ export const RadioTabs: React.FC<RadioTabsType> = ({
           >
             <input
               type="radio"
-              id={`device-${option.id}`}
+              id={`${name}-${option.id}`}
               name={name}
               value={option.id}
               checked={option.isActive}
@@ -33,14 +33,15 @@ export const RadioTabs: React.FC<RadioTabsType> = ({
               sx={{
                 opacity: 0,
                 position: "absolute",
+                pointerEvents: "none",
               }}
             />
             <label
-              htmlFor={`device-${option.id}`}
+              htmlFor={`${name}-${option.id}`}
               sx={{
                 color: option.isActive ? "primary" : "lightgrey",
                 cursor: "pointer",
-                transition: "all .1s ease-out",
+                transition: "all .1s ease-in-out",
                 "&:hover": {
                   color: "primary",
                 },

--- a/src/components/visualization/LineChart.tsx
+++ b/src/components/visualization/LineChart.tsx
@@ -58,7 +58,7 @@ export const LineChart = ({ width, height, data }: LineGraphType) => {
         top={graphHeight}
         left={paddingLeft}
         hideAxisLine={true}
-        numTicks={6}
+        numTicks={8}
         tickStroke={
           theme.colors?.mediumgrey ? `${theme.colors.mediumgrey}` : "inherit"
         }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -7,7 +7,10 @@ export const createDateValueArray = (input: RecordType[]) => {
       date: new Date(record.recordedAt),
     };
   });
-  return dateValueArray as DateValueType[];
+  const sortedDateValueArray = dateValueArray.sort((a, b) => {
+    return a.date.getTime() - b.date.getTime();
+  });
+  return sortedDateValueArray as DateValueType[];
 };
 
 export const createTimeOutput = (input: Date): string => {

--- a/src/state/model.ts
+++ b/src/state/model.ts
@@ -10,4 +10,7 @@ export interface ProjectsModel {
 
 export interface StoreModel {
   projects: ProjectsModel;
+  records: {
+    segmentSize: number;
+  };
 }

--- a/src/state/store.ts
+++ b/src/state/store.ts
@@ -22,6 +22,9 @@ const store = createStore<StoreModel>({
       actions.save(projects);
     }),
   },
+  records: {
+    segmentSize: 50,
+  },
 });
 
 export default store;

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -166,10 +166,6 @@ const theme: Theme = {
       "&:hover": {
         cursor: "pointer",
       },
-      "&:focus": {
-        bg: "lightgrey",
-        outline: "none",
-      },
     },
   },
   links: {
@@ -185,6 +181,14 @@ const theme: Theme = {
       "&:active": {
         bg: "mediumgrey",
       },
+    },
+  },
+  forms: {
+    input: {
+      border: "1px solid #D8D8D8",
+      borderRadius: "0",
+      padding: 1,
+      bg: "transparent",
     },
   },
 };


### PR DESCRIPTION
This PR introduces a short-term solution for handling large quantities of records data in the frontend.

Previously, no matter how many records were in the database, they would all be displayed by default.

This is now changed by limiting the amount of initially displayed records in the data table and in the line graph components. Both components provide a UI for changing the amount of visible records.